### PR TITLE
Instanceof not working with classes

### DIFF
--- a/src/contracts.coffee
+++ b/src/contracts.coffee
@@ -615,7 +615,8 @@ object = (objContract, options = {}, name) ->
         new bf()
       )
     else
-      op = Proxy.create(handler, Object::)
+      proto = obj?.constructor?.prototype or Object::
+      op = Proxy.create(handler, proto)
     unproxy.set op, this
     op
   )


### PR DESCRIPTION
Instanceof not working with contracted classes, because Proxy doesn't receive a correct prototype.
