### PR TITLE
Custom contracts errors with many user defined contracts not readable

### DIFF
--- a/src/contracts.coffee
+++ b/src/contracts.coffee
@@ -424,7 +424,7 @@ object = (objContract, options = {}, name) ->
           propName + " : " + obj[propName].value?.cname
       , this
 
-      "{" + props.join(", ") + "}"
+      "{\n  " + props.join(",\n  ") + "\n}"
     else
       name
 


### PR DESCRIPTION
Custom contracts errors with many user defined contracts aren't readable, mostly inside objects.

This rough patch adds some newlines to make it better, but wven with it it's quite complex in some cases.
